### PR TITLE
fix: GH Issue #12

### DIFF
--- a/sparrow-application/diag/diag.c
+++ b/sparrow-application/diag/diag.c
@@ -239,7 +239,7 @@ static void addDiagnosticNote(bool immediate)
 
     JAddNumberToObject(body, "mem.alloc.bytes", (JNUMBER)mem_info.uordblks);
     JAddNumberToObject(body, "mem.free.bytes", (JNUMBER)mem_info.fordblks);
-    // JAddNumberToObject(body, "mem.heap.bytes", (JNUMBER)MX_Heap_Size(NULL));
+    JAddNumberToObject(body, "mem.heap.bytes", (JNUMBER)MX_Heap_Size(NULL));
     JAddNumberToObject(body, "voltage", (JNUMBER)MX_ADC_A0_Voltage());
 
     // Send request to the gateway


### PR DESCRIPTION
Note body exceeding MESSAGE_MAX_BODY causes Sparrow Application Host to become unstable.