### PR TITLE
chore: PIR independence

### DIFF
--- a/sparrow-application/bme/bme.c
+++ b/sparrow-application/bme/bme.c
@@ -61,22 +61,6 @@ static bool bmeUpdate(void);
 bool bmeInit()
 {
 
-    // Register the app
-    schedAppConfig config = {
-        .name = "bme",
-        .activationPeriodSecs = 60 * 60,
-        .pollPeriodSecs = 15,
-        .activateFn = NULL,
-        .interruptFn = NULL,
-        .pollFn = bmePoll,
-        .responseFn = bmeResponse,
-        .appContext = NULL,
-    };
-    appID = schedRegisterApp(&config);
-    if (appID < 0) {
-        return false;
-    }
-
     // Power on the sensor to see if it's here
     GPIO_InitTypeDef init = {0};
     init.Speed = GPIO_SPEED_FREQ_HIGH;
@@ -91,6 +75,24 @@ bool bmeInit()
     HAL_GPIO_WritePin(BME_POWER_GPIO_Port, BME_POWER_Pin, GPIO_PIN_RESET);
     if (success) {
         appSetSKU(SKU_REFERENCE);
+    } else {
+        return false;
+    }
+
+    // Register the app
+    schedAppConfig config = {
+        .name = "bme",
+        .activationPeriodSecs = 60 * 60,
+        .pollPeriodSecs = 15,
+        .activateFn = NULL,
+        .interruptFn = NULL,
+        .pollFn = bmePoll,
+        .responseFn = bmeResponse,
+        .appContext = NULL,
+    };
+    appID = schedRegisterApp(&config);
+    if (appID < 0) {
+        return false;
     }
 
     // Done

--- a/sparrow-application/init.c
+++ b/sparrow-application/init.c
@@ -11,15 +11,11 @@
 #include "pir/pir.h"
 
 void schedAppInit (void) {
-    // Will automatically disable if BME280 is not detected
-    if (!bmeInit()) {
-        APP_PRINTF("ERROR: Failed to initialize BME280 application!\r\n");
-    }
+    // Will not initialize if BME280 is not detected
+    bmeInit();
 
-    // Will automatically disable if BME application is not detected
-    if (!pirInit()) {
-        APP_PRINTF("ERROR: Failed to initialize PIR application!\r\n");
-    }
+    // Will not initialize if not a Sparrow Reference Sensor Board
+    pirInit();
 
     // Reports node identifier and signal health information on button click
     if (!buttonInit()) {

--- a/sparrow-application/pir/pir.c
+++ b/sparrow-application/pir/pir.c
@@ -11,6 +11,13 @@
 #include <framework.h>
 #include <note.h>
 
+// Addresses of the BME sensor used to identify
+// the Sparrow Reference Sensor Board
+#define BME280_I2C_ADDR_PRIM        UINT8_C(0x76)
+#define BME280_I2C_ADDR_SEC         UINT8_C(0x77)
+#define BME280_I2C_RETRY_COUNT      3
+#define BME280_I2C_TIMEOUT_MS       100
+
 // Suppression timer for PIR activity, so that in a high-activity area
 // it isn't continuously sending messages
 #define PIR_SUPPRESSION_MINS        15
@@ -38,12 +45,18 @@ static int appID = -1;
 
 // Forwards
 static void addNote(bool immediate);
+static inline bool isSparrowReferenceSensorBoard(void);
 static bool registerNotefileTemplate(void);
 static void resetInterrupt(void);
 
 // Scheduled App One-Time Init
 bool pirInit()
 {
+
+    // Do not initialize if this isn't a Sparrow Reference Sensor Board
+    if (!isSparrowReferenceSensorBoard()) {
+        return false;
+    }
 
     // Register the app
     schedAppConfig config = {
@@ -215,13 +228,6 @@ void pirPoll(int appID, int state, void *appContext)
     // Unused parameter(s)
     (void)appContext;
 
-    // Disable if this isn't a Sparrow reference board
-    if (appSKU() != SKU_REFERENCE) {
-        HAL_NVIC_DisableIRQ(PIR_DIRECT_LINK_EXTI_IRQn);
-        schedDisable(appID);
-        return;
-    }
-
     // Switch based upon state
     switch (state) {
 
@@ -387,4 +393,25 @@ void pirISR(int appID, uint16_t pins, void *appContext)
         return;
     }
 
+}
+
+// We have no viable way of detecting whether or not the PIR sensor
+// hardware is present, so we use the presence of the BME280 as a proxy.
+bool isSparrowReferenceSensorBoard (void) {
+    bool result;
+
+    // Power on the sensor to see if it's here
+    GPIO_InitTypeDef init = {0};
+    init.Speed = GPIO_SPEED_FREQ_LOW;
+    init.Pin = BME_POWER_Pin;
+    init.Mode = GPIO_MODE_OUTPUT_PP;
+    init.Pull = GPIO_NOPULL;
+    HAL_GPIO_Init(BME_POWER_GPIO_Port, &init);
+    HAL_GPIO_WritePin(BME_POWER_GPIO_Port, BME_POWER_Pin, GPIO_PIN_SET);
+    MX_I2C2_Init();
+    result = (MY_I2C2_Ping(BME280_I2C_ADDR_PRIM, BME280_I2C_TIMEOUT_MS, BME280_I2C_RETRY_COUNT)
+           || MY_I2C2_Ping(BME280_I2C_ADDR_SEC, BME280_I2C_TIMEOUT_MS, BME280_I2C_RETRY_COUNT));
+    MX_I2C2_DeInit();
+
+    return result;
 }


### PR DESCRIPTION
Refactor BME and PIR applications init sequence
- PIR uses I2C ping to test for BME
- Silence warnings so Sparrow Essentials Board does not send spurious error messages